### PR TITLE
Defaults color scheme to `g:colors_name` or `"NONE"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ The author of this script uses an extended installation approach based on
 
 Once `spell-under` is installed, Vim behaves as follows:
 
-* If `g:spell_under` is unset in `.vimrc`, `spell-under` executes
-  `:colorscheme murphy` and fixes up spell checker to use "UNDERLINE".
+* If `g:spell_under` is unset in `.vimrc`, `spell-under` defaults to using
+  `colorscheme` (via `g:colors_name`), or `"NONE"` if both are undefined.
 * If `.vimrc` has `let g:spell_under='<scheme>'`, `spell-under` executes
   `:colorscheme <scheme>` and fixes up spell checker to use "UNDERLINE".
 * If `.vimrc` has `let g:spell_under='NONE'`, `spell-under` doesn't executes
   `:colorscheme <scheme>`.
-* When you execute `colorscheme <scheme>` from any scipt after parsing this
+* When you execute `colorscheme <scheme>` from any script after parsing this
   plugin or from the vim command prompt, vim sets colorscheme accordingly and
   fixes up spell checker to use "UNDERLINE".
 * If `g:loaded_spell_under` is set to 1, `spell-under` plugin has been

--- a/plugin/spell-under.vim
+++ b/plugin/spell-under.vim
@@ -48,7 +48,7 @@ augroup SpellUnderline
 " Available color schemes in the baseline vim:
 "   blue darkblue default delek desert elflord evening industry koehler
 "   morning murphy pablo peachpuff ron shine slate torte zellner
-let s:spell_under =  get(g:, 'spell_under', 'murphy')
+let s:spell_under =  get(g:, 'spell_under', get(g:, 'colors_name', 'NONE'))
 if s:spell_under !=# 'NONE'
   exec 'colorscheme ' . s:spell_under
 endif


### PR DESCRIPTION
These changes _should_ avoid changing an already defined `colorscheme`.

I've tested without setting `spell_under` both with, and without, a `colorscheme` defined, and things seem to function predictably.